### PR TITLE
FHIRWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use this project, you should perform the following steps:
 2. Install [Yarn](https://yarnpkg.com/en/docs/install)
 3. Execute the following from this project's root directory: `yarn`
 
-# Using the FHIR Data Source
+# Using the FHIR Patient Data Source
 
 The FHIR Data Source expects each patient to be represented as a single FHIR Bundle containing all of the patient's
 relevant data.  The FHIR Data Source does _not_ query FHIR servers, but rather, expects the Bundles to be passed to
@@ -28,6 +28,22 @@ const cqlfhir = require('cql-exec-fhir');
 const patientSource = cqlfhir.PatientSource.FHIRv102(); // or .FHIRv300()
 patientSource.loadBundles([patient01, patient02]);
 const results = executor.exec(patientSource);
+```
+
+# Using the FHIRWrapper
+
+If you are passing in individual fhir resources to the execution engine as parameters, you can use FHIRWrapper
+to convert the raw json FHIR resources into FHIRObjects that work with the execution engine.
+
+Example:
+
+```js
+const cqlfhir = require('cql-exec-fhir');
+const fhirWrapper = cqlfhir.FHIRWrapper.FHIRv300();
+
+const conditionRawResource = { "resourceType": "Condition", "id": "f201", "clinicalStatus": "active", ... }
+const conditionFhirObject = fhirWrapper.wrap(conditionResource)
+// Now conditionFhirObject can be passed into the cql execution engine
 ```
 
 # Linting the Code

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const results = executor.exec(patientSource);
 
 # Using the FHIRWrapper
 
-If you are passing in individual fhir resources to the execution engine as parameters, you can use FHIRWrapper
+If you are passing in individual FHIR resources to the execution engine as parameters, you can use FHIRWrapper
 to convert the raw json FHIR resources into FHIRObjects that work with the execution engine.
 
 Example:

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -18,8 +18,8 @@ class FHIRWrapper {
 
   wrap(fhirJson, fhirResourceType = null) {
     fhirResourceType = fhirResourceType || fhirJson.resourceType;
-    const typeInfo = this._modelInfo.findClass(fhirResourceType)
-    return new FHIRObject(fhirJson, typeInfo, this._modelInfo)
+    const typeInfo = this._modelInfo.findClass(fhirResourceType);
+    return new FHIRObject(fhirJson, typeInfo, this._modelInfo);
   }
 }
 

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -24,7 +24,7 @@ class FHIRWrapper {
     if (fhirResourceType && fhirJson.resourceType) {
       const currentClass = this._modelInfo.findClass(fhirJson.resourceType);
       if (!this._typeCastIsAllowed(currentClass, targetClass))
-        throw `Incompatible types: fhir resourceType is ${fhirJson.resourceType} which cannot be cast as ${fhirResourceType}`;
+        throw `Incompatible types: FHIR resourceType is ${fhirJson.resourceType} which cannot be cast as ${fhirResourceType}`;
     }
 
     return new FHIRObject(fhirJson, targetClass, this._modelInfo);

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -3,6 +3,26 @@ const load = require('./load');
 const FHIRv102XML = require('./modelInfos/fhir-modelinfo-1.0.2.xml.js');
 const FHIRv300XML = require('./modelInfos/fhir-modelinfo-3.0.0.xml.js');
 
+class FHIRWrapper {
+  constructor(filePathOrXML) {
+    this._modelInfo = load(filePathOrXML);
+  }
+
+  static FHIRv102() {
+    return new FHIRWrapper(FHIRv102XML);
+  }
+
+  static FHIRv300() {
+    return new FHIRWrapper(FHIRv300XML);
+  }
+
+  wrap(fhirJson, fhirResourceType = null) {
+    fhirResourceType = fhirResourceType || fhirJson.resourceType;
+    const typeInfo = this._modelInfo.findClass(fhirResourceType)
+    return new FHIRObject(fhirJson, typeInfo, this._modelInfo)
+  }
+}
+
 class PatientSource {
   constructor(filePathOrXML) {
     this._index = 0;
@@ -397,4 +417,4 @@ function toCode(f) {
   return new cql.Code(f.code.value);
 }
 
-module.exports = { PatientSource };
+module.exports = { PatientSource, FHIRWrapper };

--- a/src/load.js
+++ b/src/load.js
@@ -115,6 +115,7 @@ class ClassInfo {
         this._elementsByName.set(element.name, element);
       }
     }
+    this._parentClasses = null; //lazy loaded
   }
 
   get name() { return this._name; }
@@ -124,6 +125,19 @@ class ClassInfo {
   get primaryCodePath() { return this._primaryCodePath; }
   get baseTypeSpecifier() { return this._baseTypeSpecifier; }
   get elements() { return Array.from(this._elementsByName.values()); }
+
+  // @return NamedTypeSpecifier
+  parentClasses() {
+    if (!this._parentClasses) {
+      this._parentClasses = [];
+      let klass = this;
+      while (klass && klass.baseTypeSpecifier) {
+        klass = this._modelInfo.findClass(klass.baseTypeSpecifier.name);
+        if (klass) this._parentClasses.push(klass);
+      }
+    }
+    return this._parentClasses;
+  }
 
   /**
    * Finds an element by name, optionally allowing for explicit choice names. If explicit choice names

--- a/src/load.js
+++ b/src/load.js
@@ -130,10 +130,9 @@ class ClassInfo {
   parentClasses() {
     if (!this._parentClasses) {
       this._parentClasses = [];
-      let klass = this;
-      while (klass && klass.baseTypeSpecifier) {
-        klass = this._modelInfo.findClass(klass.baseTypeSpecifier.name);
-        if (klass) this._parentClasses.push(klass);
+      if (this.baseTypeSpecifier) {
+        const parentClass = this._modelInfo.findClass(this.baseTypeSpecifier.name);
+        if (parentClass) this._parentClasses.push(parentClass, ...parentClass.parentClasses());
       }
     }
     return this._parentClasses;

--- a/test/dstu2_test.js
+++ b/test/dstu2_test.js
@@ -7,16 +7,16 @@ describe('#FHIRWrapper_DSTU2', () => {
   let conditionResource;
   before(() => {
     fhirWrapper = cqlfhir.FHIRWrapper.FHIRv102();
-    conditionResource = require('./fixtures/dstu2/Condition_f201.json')
+    conditionResource = require('./fixtures/dstu2/Condition_f201.json');
   });
 
   it('should wrap a fhir resource to the correct type when type not specified', () => {
-    let fhirObject = fhirWrapper.wrap(conditionResource)
+    let fhirObject = fhirWrapper.wrap(conditionResource);
     expect(fhirObject.getTypeInfo().name).to.equal('FHIR.Condition');
   });
 
   it('should wrap a fhir resource to the type specified', () => {
-    let fhirObject = fhirWrapper.wrap(conditionResource, 'Observation')
+    let fhirObject = fhirWrapper.wrap(conditionResource, 'Observation');
     expect(fhirObject.getTypeInfo().name).to.equal('FHIR.Observation');
   });
 });

--- a/test/dstu2_test.js
+++ b/test/dstu2_test.js
@@ -36,7 +36,7 @@ describe('#FHIRWrapper_DSTU2', () => {
   });
 
   it('should error if requested type is incompatible', () => {
-    expect(function(){fhirWrapper.wrap(conditionResource, 'Observation');}).to.throw('Incompatible types: fhir resourceType is Condition which cannot be cast as Observation');
+    expect(function(){fhirWrapper.wrap(conditionResource, 'Observation');}).to.throw('Incompatible types: FHIR resourceType is Condition which cannot be cast as Observation');
   });
 
   it('should wrap a fhir resource to the type specified if real type unknown', () => {

--- a/test/dstu2_test.js
+++ b/test/dstu2_test.js
@@ -2,6 +2,25 @@ const cql = require('cql-execution');
 const cqlfhir = require('../src/index');
 const {expect} = require('chai');
 
+describe('#FHIRWrapper_DSTU2', () => {
+  let fhirWrapper;
+  let conditionResource;
+  before(() => {
+    fhirWrapper = cqlfhir.FHIRWrapper.FHIRv102();
+    conditionResource = require('./fixtures/dstu2/Condition_f201.json')
+  });
+
+  it('should wrap a fhir resource to the correct type when type not specified', () => {
+    let fhirObject = fhirWrapper.wrap(conditionResource)
+    expect(fhirObject.getTypeInfo().name).to.equal('FHIR.Condition');
+  });
+
+  it('should wrap a fhir resource to the type specified', () => {
+    let fhirObject = fhirWrapper.wrap(conditionResource, 'Observation')
+    expect(fhirObject.getTypeInfo().name).to.equal('FHIR.Observation');
+  });
+});
+
 // Placeholder test
 describe('#DSTU2', () => {
   let patientSource;

--- a/test/fixtures/dstu2/Condition_f201.json
+++ b/test/fixtures/dstu2/Condition_f201.json
@@ -1,0 +1,105 @@
+{
+  "resourceType": "Condition",
+  "id": "f201",
+  "text": {
+    "status": "generated",
+    "div": "<div><p><b>Generated Narrative with Details</b></p><p><b>id</b>: f201</p><p><b>patient</b>: <a>Roel</a></p><p><b>encounter</b>: <a>Encounter/f201</a></p><p><b>asserter</b>: <a>Practitioner/f201</a></p><p><b>dateRecorded</b>: 04/04/2013</p><p><b>code</b>: Fever <span>(Details : {SNOMED CT code '386661006' = '386661006', given as 'Fever'})</span></p><p><b>category</b>: Problem <span>(Details : {SNOMED CT code '55607006' = '55607006', given as 'Problem'}; {http://hl7.org/fhir/condition-category code 'finding' = 'Finding)</span></p><p><b>clinicalStatus</b>: active</p><p><b>verificationStatus</b>: confirmed</p><p><b>severity</b>: Mild <span>(Details : {SNOMED CT code '255604002' = '255604002', given as 'Mild'})</span></p><p><b>onset</b>: 02/04/2013</p><h3>Evidences</h3><table><tr><td>-</td><td><b>Code</b></td><td><b>Detail</b></td></tr><tr><td>*</td><td>degrees C <span>(Details : {SNOMED CT code '258710007' = '258710007', given as 'degrees C'})</span></td><td><a>Temperature</a></td></tr></table><p><b>bodySite</b>: Entire body as a whole <span>(Details : {SNOMED CT code '38266002' = '38266002', given as 'Entire body as a whole'})</span></p></div>"
+  },
+  "patient": {
+    "reference": "Patient/f201",
+    "display": "Roel"
+  },
+  "encounter": {
+    "reference": "Encounter/f201"
+  },
+  "asserter": {
+    "reference": "Practitioner/f201"
+  },
+  "dateRecorded": "2013-04-04",
+  "code": {
+    "fhir_comments": [
+      "  The problem was entered at April fourth  "
+    ],
+    "coding": [
+      {
+        "fhir_comments": [
+          "  The problem is a fever  "
+        ],
+        "system": "http://snomed.info/sct",
+        "code": "386661006",
+        "display": "Fever"
+      }
+    ]
+  },
+  "category": {
+    "coding": [
+      {
+        "fhir_comments": [
+          "  The fever is a mild problem  "
+        ],
+        "system": "http://snomed.info/sct",
+        "code": "55607006",
+        "display": "Problem"
+      },
+      {
+        "system": "http://hl7.org/fhir/condition-category",
+        "code": "finding"
+      }
+    ]
+  },
+  "clinicalStatus": "active",
+  "verificationStatus": "confirmed",
+  "severity": {
+    "coding": [
+      {
+        "fhir_comments": [
+          "  The fever is mild   "
+        ],
+        "system": "http://snomed.info/sct",
+        "code": "255604002",
+        "display": "Mild"
+      }
+    ]
+  },
+  "onsetDateTime": "2013-04-02",
+  "evidence": [
+    {
+      "fhir_comments": [
+        "  Problem began on April second  ",
+        "  No remission means no <rebatement>  "
+      ],
+      "code": {
+        "fhir_comments": [
+          "  Problem is confirmed by 39 degrees Celsius  "
+        ],
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "258710007",
+            "display": "degrees C"
+          }
+        ]
+      },
+      "detail": [
+        {
+          "reference": "Observation/f202",
+          "display": "Temperature"
+        }
+      ]
+    }
+  ],
+  "bodySite": [
+    {
+      "coding": [
+        {
+          "fhir_comments": [
+            "  Fever applies to whole body  "
+          ],
+          "system": "http://snomed.info/sct",
+          "code": "38266002",
+          "display": "Entire body as a whole"
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/stu3/Condition_f201.json
+++ b/test/fixtures/stu3/Condition_f201.json
@@ -1,0 +1,93 @@
+{
+  "resourceType": "Condition",
+  "id": "f201",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative with Details</b></p><p><b>id</b>: f201</p><p><b>identifier</b>: 12345</p><p><b>clinicalStatus</b>: resolved</p><p><b>verificationStatus</b>: confirmed</p><p><b>category</b>: Problem <span>(Details : {SNOMED CT code '55607006' = 'Problem', given as 'Problem'}; {http://hl7.org/fhir/condition-category code 'problem-list-item' = 'Problem List Item)</span></p><p><b>severity</b>: Mild <span>(Details : {SNOMED CT code '255604002' = 'Mild', given as 'Mild'})</span></p><p><b>code</b>: Fever <span>(Details : {SNOMED CT code '386661006' = 'Fever', given as 'Fever'})</span></p><p><b>bodySite</b>: Entire body as a whole <span>(Details : {SNOMED CT code '38266002' = 'Body as a whole', given as 'Entire body as a whole'})</span></p><p><b>subject</b>: <a>Roel</a></p><p><b>context</b>: <a>Encounter/f201</a></p><p><b>onset</b>: 02/04/2013</p><p><b>abatement</b>: around April 9, 2013</p><p><b>assertedDate</b>: 04/04/2013</p><p><b>asserter</b>: <a>Practitioner/f201</a></p><h3>Evidences</h3><table><tr><td>-</td><td><b>Code</b></td><td><b>Detail</b></td></tr><tr><td>*</td><td>degrees C <span>(Details : {SNOMED CT code '258710007' = 'degrees C', given as 'degrees C'})</span></td><td><a>Temperature</a></td></tr></table></div>"
+  },
+  "identifier": [
+    {
+      "value": "12345"
+    }
+  ],
+  "clinicalStatus": "resolved",
+  "verificationStatus": "confirmed",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "55607006",
+          "display": "Problem"
+        },
+        {
+          "system": "http://hl7.org/fhir/condition-category",
+          "code": "problem-list-item"
+        }
+      ]
+    }
+  ],
+  "severity": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "255604002",
+        "display": "Mild"
+      }
+    ]
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "386661006",
+        "display": "Fever"
+      }
+    ]
+  },
+  "bodySite": [
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "38266002",
+          "display": "Entire body as a whole"
+        }
+      ]
+    }
+  ],
+  "subject": {
+    "reference": "Patient/f201",
+    "display": "Roel"
+  },
+  "context": {
+    "reference": "Encounter/f201"
+  },
+  "onsetDateTime": "2013-04-02",
+  "abatementString": "around April 9, 2013",
+  "assertedDate": "2013-04-04",
+  "asserter": {
+    "reference": "Practitioner/f201"
+  },
+  "evidence": [
+    {
+      "code": [
+        {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "258710007",
+              "display": "degrees C"
+            }
+          ]
+        }
+      ],
+      "detail": [
+        {
+          "reference": "Observation/f202",
+          "display": "Temperature"
+        }
+      ]
+    }
+  ]
+}

--- a/test/stu3_test.js
+++ b/test/stu3_test.js
@@ -36,7 +36,7 @@ describe('#FHIRWrapper_STU3', () => {
   });
 
   it('should error if requested type is incompatible', () => {
-    expect(function(){fhirWrapper.wrap(conditionResource, 'Observation');}).to.throw('Incompatible types: fhir resourceType is Condition which cannot be cast as Observation');
+    expect(function(){fhirWrapper.wrap(conditionResource, 'Observation');}).to.throw('Incompatible types: FHIR resourceType is Condition which cannot be cast as Observation');
   });
 
   it('should wrap a fhir resource to the type specified if real type unknown', () => {

--- a/test/stu3_test.js
+++ b/test/stu3_test.js
@@ -5,9 +5,15 @@ const {expect} = require('chai');
 describe('#FHIRWrapper_STU3', () => {
   let fhirWrapper;
   let conditionResource;
+  let conditionResourceWithNoType;
+  let domainResource;
   before(() => {
     fhirWrapper = cqlfhir.FHIRWrapper.FHIRv300();
     conditionResource = require('./fixtures/stu3/Condition_f201.json');
+    conditionResourceWithNoType = JSON.parse(JSON.stringify(conditionResource));
+    delete conditionResourceWithNoType.resourceType;
+    domainResource = JSON.parse(JSON.stringify(conditionResource));
+    domainResource.resourceType = 'DomainResource';
   });
 
   it('should wrap a fhir resource to the correct type when type not specified', () => {
@@ -15,8 +21,26 @@ describe('#FHIRWrapper_STU3', () => {
     expect(fhirObject.getTypeInfo().name).to.equal('Condition');
   });
 
-  it('should wrap a fhir resource to the type specified', () => {
-    let fhirObject = fhirWrapper.wrap(conditionResource, 'Observation');
+  it('should wrap a fhir resource to the type specified if upcasting', () => {
+    // inheritance is: Condition < DomainResource < Resource
+    let fhirObject = fhirWrapper.wrap(conditionResource, 'DomainResource');
+    expect(fhirObject.getTypeInfo().name).to.equal('DomainResource');
+    fhirObject = fhirWrapper.wrap(conditionResource, 'Resource');
+    expect(fhirObject.getTypeInfo().name).to.equal('Resource');
+  });
+
+  it('should wrap a fhir resource to the type specified if downcasting', () => {
+    // inheritance is: Condition < DomainResource < Resource
+    let fhirObject = fhirWrapper.wrap(domainResource, 'Condition');
+    expect(fhirObject.getTypeInfo().name).to.equal('Condition');
+  });
+
+  it('should error if requested type is incompatible', () => {
+    expect(function(){fhirWrapper.wrap(conditionResource, 'Observation');}).to.throw('Incompatible types: fhir resourceType is Condition which cannot be cast as Observation');
+  });
+
+  it('should wrap a fhir resource to the type specified if real type unknown', () => {
+    let fhirObject = fhirWrapper.wrap(conditionResourceWithNoType, 'Observation');
     expect(fhirObject.getTypeInfo().name).to.equal('Observation');
   });
 });

--- a/test/stu3_test.js
+++ b/test/stu3_test.js
@@ -7,16 +7,16 @@ describe('#FHIRWrapper_STU3', () => {
   let conditionResource;
   before(() => {
     fhirWrapper = cqlfhir.FHIRWrapper.FHIRv300();
-    conditionResource = require('./fixtures/stu3/Condition_f201.json')
+    conditionResource = require('./fixtures/stu3/Condition_f201.json');
   });
 
   it('should wrap a fhir resource to the correct type when type not specified', () => {
-    let fhirObject = fhirWrapper.wrap(conditionResource)
+    let fhirObject = fhirWrapper.wrap(conditionResource);
     expect(fhirObject.getTypeInfo().name).to.equal('Condition');
   });
 
   it('should wrap a fhir resource to the type specified', () => {
-    let fhirObject = fhirWrapper.wrap(conditionResource, 'Observation')
+    let fhirObject = fhirWrapper.wrap(conditionResource, 'Observation');
     expect(fhirObject.getTypeInfo().name).to.equal('Observation');
   });
 });

--- a/test/stu3_test.js
+++ b/test/stu3_test.js
@@ -2,6 +2,25 @@ const cql = require('cql-execution');
 const cqlfhir = require('../src/index');
 const {expect} = require('chai');
 
+describe('#FHIRWrapper_STU3', () => {
+  let fhirWrapper;
+  let conditionResource;
+  before(() => {
+    fhirWrapper = cqlfhir.FHIRWrapper.FHIRv300();
+    conditionResource = require('./fixtures/stu3/Condition_f201.json')
+  });
+
+  it('should wrap a fhir resource to the correct type when type not specified', () => {
+    let fhirObject = fhirWrapper.wrap(conditionResource)
+    expect(fhirObject.getTypeInfo().name).to.equal('Condition');
+  });
+
+  it('should wrap a fhir resource to the type specified', () => {
+    let fhirObject = fhirWrapper.wrap(conditionResource, 'Observation')
+    expect(fhirObject.getTypeInfo().name).to.equal('Observation');
+  });
+});
+
 // Placeholder test
 describe('#STU3', () => {
   let patientSource;


### PR DESCRIPTION
This PR adds a public FHIRWrapper class that can be used to convert individual FHIR resources. The use case is if FHIR resources are passed in as parameters to cql-execution, they must first be wrapped.

I am very open to suggestions on this PR.