### PR TITLE
Fix undefined code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql-exec-fhir",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Provides a FHIR-based data source for use w/ CQL",
   "author": "Chris Moesel <cmoesel@mitre.org>",
   "license": "Apache-2.0",

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -446,9 +446,10 @@ function toCode(f) {
       return codings.length === 1 ? codings[0] : codings;
     }
   } else if (typeName === 'Coding') {
-    return new cql.Code(f.code.value, f.system ? f.system.value : f.system, f.version ? f.version.value : f.version, f.display ? f.display.value : f.display);
+    return new cql.Code(f.code ? f.code.value : f.code, f.system ? f.system.value : f.system, f.version ? f.version.value : f.version, f.display ? f.display.value : f.display);
+  } else if (typeName === 'code') {
+    return f.value;
   }
-  return new cql.Code(f.code.value);
 }
 
 module.exports = { PatientSource, FHIRWrapper };

--- a/test/fixtures/r4/Luna60_McCullough561_6662f0ca-b617-4e02-8f55-7275e9f49aa0.json
+++ b/test/fixtures/r4/Luna60_McCullough561_6662f0ca-b617-4e02-8f55-7275e9f49aa0.json
@@ -5813,6 +5813,33 @@
       }
     },
     {
+      "fullUrl": "urn:uuid:622c5788-3028-41fd-a8cb-164f868d4323",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "622c5788-3028-41fd-a8cb-164f868d4323",
+        "status": "stopped",
+        "intent": "order",
+        "medicationReference": {
+          "reference": "urn:uuid:622c5788-3028-41fd-a8cb-164f868d4324",
+          "display": "Cefuroxime 250 MG Oral Tablet"
+        },
+        "subject": {
+          "reference": "urn:uuid:356a0ab8-5592-4ec5-8c3a-9a4d0857b793"
+        },
+        "encounter": {
+          "reference": "urn:uuid:45761e8d-e80a-4abd-817f-99c196027124"
+        },
+        "authoredOn": "2009-12-01T11:18:29-05:00",
+        "requester": {
+          "reference": "urn:uuid:558f4663-58a9-418c-809e-cfdc4f0ae6b4"
+        }
+      },
+      "request": {
+        "method": "POST",
+        "url": "MedicationRequest"
+      }
+    },
+    {
       "fullUrl": "urn:uuid:740826c7-610f-4d30-b5af-8483c30a3f47",
       "resource": {
         "resourceType": "Claim",

--- a/test/r4_test.js
+++ b/test/r4_test.js
@@ -298,6 +298,14 @@ describe('#R4 v4.0.0', () => {
     expect(ref).to.be.undefined;
   });
 
+  it('should return undefined when attempting to get the code on a choice that is a reference', () => {
+    // This was a bug that surfaced when testing some CQL against Synthea patients that use medicationReference
+    const pt = patientSource.currentPatient();
+    const medReq = pt.findRecords('MedicationRequest').find(p => p.getId() === '622c5788-3028-41fd-a8cb-164f868d4323');
+    const ref = medReq.getCode('medication');
+    expect(ref).to.be.undefined;
+  });
+
   it('should support id and extension on primitives', () => {
     const pt = patientSource.currentPatient();
     const encounter = pt.findRecords('Encounter').find(p => p.getId() === '9d911534-10d8-4dc2-91f1-d7aeed828af8');


### PR DESCRIPTION
Sometimes a value set based retrieve operates on a choice property, as is the case with `MedicationRequest` in FHIR R4 (which uses 'medication' as the codepath property):
```
[MedicationRequest: "Aspirin"]
```

The above will result in cql-execution calling `getCode('medication')` on each `MedicationRequest`.  If a `MedicationRequest` uses `medicationReference` instead of `medicationCodeableConcept`, then `getCode` will be passed in a `Reference` value instead of a `CodeableConcept` value.  This caused an error to be thrown because cql-exec-fhir's `toCode` function was trying to access `code.value` on a `Reference` object -- and since `code` was undefined, it threw.

This is fixed by checking to ensure that the property passed in is one of the valid code types.  We partially checked, but didn't fully check.  Now we're more thorough.