### PR TITLE
Support multiple namespaces in type hierarchy

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -241,17 +241,23 @@ class FHIRObject {
   }
 
   _is(namespace, name) {
-    const typeHierarchy = this._typeHierarchy();
-    return namespace === 'http://hl7.org/fhir' && typeHierarchy.includes(name);
+    return this._typeHierarchy().some(t => t.namespace === namespace && t.name == name);
   }
 
   _typeHierarchy() {
-    let parentTypes = [];
-    if (this.getTypeInfo() !== undefined && this.getTypeInfo().parentClasses() !== undefined) {
-      parentTypes = this.getTypeInfo().parentClasses().map(c => c.name);
+    let typeHierarchy = [];
+    if (this.getTypeInfo() != null) {
+      typeHierarchy = [this.getTypeInfo(), ...this.getTypeInfo().parentClasses()].map(c => {
+        return {
+          namespace: c.namespace,
+          name: c.name
+        };
+      });
     }
-    parentTypes.unshift(this.getTypeInfo().name);
-    return parentTypes;
+    // TODO: This currently doesn't include System types in the hierarchy.  We should fix this in the parentClasses
+    // function, but until then, we know that everything eventually inherits from System.Any, so force that here:
+    typeHierarchy.push({ namespace: 'urn:hl7-org:elm-types:r1', name: 'Any' });
+    return typeHierarchy;
   }
 
   getTypeInfo() { return this._typeInfo; }

--- a/src/load.js
+++ b/src/load.js
@@ -100,7 +100,7 @@ class ModelInfo {
 
 class ClassInfo {
   constructor(xml, modelInfo) {
-    this._namespace = xml.$.namespace;
+    this._namespace = xml.$.namespace || modelInfo.url;
     this._name = xml.$.name;
     this._identifier = xml.$.identifier;
     this._label = xml.$.label;
@@ -118,6 +118,7 @@ class ClassInfo {
     this._parentClasses = null; //lazy loaded
   }
 
+  get namespace() { return this._namespace; }
   get name() { return this._name; }
   get identifier() { return this._identifier; }
   get label() { return this._label; }

--- a/test/r4_test.js
+++ b/test/r4_test.js
@@ -324,6 +324,28 @@ describe('#R4 v4.0.0', () => {
       { value: 'Apt. C' }
     ]);
   });
+
+  it('should support _typeHierarchy', () =>{
+    const pt = patientSource.currentPatient();
+    const condition = pt.findRecord('Condition');
+    expect(condition._typeHierarchy()).to.eql([
+      { name: 'Condition', namespace: 'http://hl7.org/fhir'},
+      { name: 'DomainResource', namespace: 'http://hl7.org/fhir'},
+      { name: 'Resource', namespace: 'http://hl7.org/fhir'},
+      { name: 'Any', namespace: 'urn:hl7-org:elm-types:r1'}
+    ]);
+  });
+
+  it('should support _is', () =>{
+    const pt = patientSource.currentPatient();
+    const condition = pt.findRecord('Condition');
+    expect(condition._is('http://hl7.org/fhir', 'Condition')).to.be.true;
+    expect(condition._is('http://hl7.org/fhir', 'DomainResource')).to.be.true;
+    expect(condition._is('http://hl7.org/fhir', 'Resource')).to.be.true;
+    expect(condition._is('urn:hl7-org:elm-types:r1', 'Any')).to.be.true;
+    expect(condition._is('http://some.other.model.org', 'Condition')).to.be.false;
+    expect(condition._is('http://hl7.org/fhir', 'Observation')).to.be.false;
+  });
 });
 
 function compact(obj) {


### PR DESCRIPTION
Since a type in one model can extend a type from a different model, the typeHierarchy needs to return the namespace and name. In the FHIR model, this most often happens with FHIR types extending System.Any.  This commit doesn't fully fix support for type hierarchy w/ System types, but it partially supports and fakes it for now.