### PR TITLE
Refactor _is and typeHierarchy to use type specifiers, as they come out of the CQL, and update the tests

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -240,8 +240,10 @@ class FHIRObject {
     return dateOrIvl;
   }
 
-  _is(namespace, name) {
-    return this._typeHierarchy().some(t => t.namespace === namespace && t.name == name);
+  _is(typeSpecifier) {
+    return this._typeHierarchy().some(
+      (t) => t.type === typeSpecifier.type && t.name == typeSpecifier.name
+    );
   }
 
   _typeHierarchy() {
@@ -260,12 +262,14 @@ class FHIRObject {
         if (name.startsWith(`${c.modelInfo.name}.`)) {
           name = name.slice(c.modelInfo.name.length + 1);
         }
-        return { namespace, name };
+        name = `{${namespace}}${name}`;
+        // At this point, all the FHIR models are considered named types
+        return { name, type: 'NamedTypeSpecifier' };
       });
     }
     // TODO: This currently doesn't include System types in the hierarchy.  We should fix this in the parentClasses
     // function, but until then, we know that everything eventually inherits from System.Any, so force that here:
-    typeHierarchy.push({ namespace: 'urn:hl7-org:elm-types:r1', name: 'Any' });
+    typeHierarchy.push({name: '{urn:hl7-org:elm-types:r1}Any', type: 'NamedTypeSpecifier' });
     return typeHierarchy;
   }
 

--- a/test/dstu2_test.js
+++ b/test/dstu2_test.js
@@ -299,26 +299,27 @@ describe('#DSTU2', () => {
     ]);
   });
 
-  it('should support _typeHierarchy', () =>{
+  it('should support _typeHierarchy', () => {
     const pt = patientSource.currentPatient();
     const condition = pt.findRecord('Condition');
     expect(condition._typeHierarchy()).to.eql([
-      { name: 'Condition', namespace: 'http://hl7.org/fhir'},
-      { name: 'DomainResource', namespace: 'http://hl7.org/fhir'},
-      { name: 'Resource', namespace: 'http://hl7.org/fhir'},
-      { name: 'Any', namespace: 'urn:hl7-org:elm-types:r1'}
+      { name: '{http://hl7.org/fhir}Condition', type: 'NamedTypeSpecifier' },
+      { name: '{http://hl7.org/fhir}DomainResource', type: 'NamedTypeSpecifier' },
+      { name: '{http://hl7.org/fhir}Resource', type: 'NamedTypeSpecifier' },
+      { name: '{urn:hl7-org:elm-types:r1}Any', type: 'NamedTypeSpecifier' },
     ]);
   });
 
-  it('should support _is', () =>{
+  it('should support _is', () => {
     const pt = patientSource.currentPatient();
     const condition = pt.findRecord('Condition');
-    expect(condition._is('http://hl7.org/fhir', 'Condition')).to.be.true;
-    expect(condition._is('http://hl7.org/fhir', 'DomainResource')).to.be.true;
-    expect(condition._is('http://hl7.org/fhir', 'Resource')).to.be.true;
-    expect(condition._is('urn:hl7-org:elm-types:r1', 'Any')).to.be.true;
-    expect(condition._is('http://some.other.model.org', 'Condition')).to.be.false;
-    expect(condition._is('http://hl7.org/fhir', 'Observation')).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Condition', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://hl7.org/fhir}DomainResource', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://hl7.org/fhir}Resource', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{urn:hl7-org:elm-types:r1}Any', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://some.other.model.org}Condition', type: 'NamedTypeSpecifier'})).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Observation', type: 'NamedTypeSpecifier'})).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Condition', type: 'IntervalTypeSpecifier'})).to.be.false;
   });
 });
 

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -304,23 +304,23 @@ describe('#R4 v4.0.1', () => {
     const pt = patientSource.currentPatient();
     const condition = pt.findRecord('Condition');
     expect(condition._typeHierarchy()).to.eql([
-      { name: 'Condition', namespace: 'http://hl7.org/fhir' },
-      { name: 'DomainResource', namespace: 'http://hl7.org/fhir' },
-      { name: 'Resource', namespace: 'http://hl7.org/fhir' },
-      { name: 'Any', namespace: 'urn:hl7-org:elm-types:r1' },
+      { name: '{http://hl7.org/fhir}Condition', type: 'NamedTypeSpecifier' },
+      { name: '{http://hl7.org/fhir}DomainResource', type: 'NamedTypeSpecifier' },
+      { name: '{http://hl7.org/fhir}Resource', type: 'NamedTypeSpecifier' },
+      { name: '{urn:hl7-org:elm-types:r1}Any', type: 'NamedTypeSpecifier' },
     ]);
   });
 
   it('should support _is', () => {
     const pt = patientSource.currentPatient();
     const condition = pt.findRecord('Condition');
-    expect(condition._is('http://hl7.org/fhir', 'Condition')).to.be.true;
-    expect(condition._is('http://hl7.org/fhir', 'DomainResource')).to.be.true;
-    expect(condition._is('http://hl7.org/fhir', 'Resource')).to.be.true;
-    expect(condition._is('urn:hl7-org:elm-types:r1', 'Any')).to.be.true;
-    expect(condition._is('http://some.other.model.org', 'Condition')).to.be
-      .false;
-    expect(condition._is('http://hl7.org/fhir', 'Observation')).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Condition', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://hl7.org/fhir}DomainResource', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://hl7.org/fhir}Resource', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{urn:hl7-org:elm-types:r1}Any', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://some.other.model.org}Condition', type: 'NamedTypeSpecifier'})).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Observation', type: 'NamedTypeSpecifier'})).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Condition', type: 'IntervalTypeSpecifier'})).to.be.false;
   });
 });
 

--- a/test/r4_test.js
+++ b/test/r4_test.js
@@ -325,26 +325,27 @@ describe('#R4 v4.0.0', () => {
     ]);
   });
 
-  it('should support _typeHierarchy', () =>{
+  it('should support _typeHierarchy', () => {
     const pt = patientSource.currentPatient();
     const condition = pt.findRecord('Condition');
     expect(condition._typeHierarchy()).to.eql([
-      { name: 'Condition', namespace: 'http://hl7.org/fhir'},
-      { name: 'DomainResource', namespace: 'http://hl7.org/fhir'},
-      { name: 'Resource', namespace: 'http://hl7.org/fhir'},
-      { name: 'Any', namespace: 'urn:hl7-org:elm-types:r1'}
+      { name: '{http://hl7.org/fhir}Condition', type: 'NamedTypeSpecifier' },
+      { name: '{http://hl7.org/fhir}DomainResource', type: 'NamedTypeSpecifier' },
+      { name: '{http://hl7.org/fhir}Resource', type: 'NamedTypeSpecifier' },
+      { name: '{urn:hl7-org:elm-types:r1}Any', type: 'NamedTypeSpecifier' },
     ]);
   });
 
-  it('should support _is', () =>{
+  it('should support _is', () => {
     const pt = patientSource.currentPatient();
     const condition = pt.findRecord('Condition');
-    expect(condition._is('http://hl7.org/fhir', 'Condition')).to.be.true;
-    expect(condition._is('http://hl7.org/fhir', 'DomainResource')).to.be.true;
-    expect(condition._is('http://hl7.org/fhir', 'Resource')).to.be.true;
-    expect(condition._is('urn:hl7-org:elm-types:r1', 'Any')).to.be.true;
-    expect(condition._is('http://some.other.model.org', 'Condition')).to.be.false;
-    expect(condition._is('http://hl7.org/fhir', 'Observation')).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Condition', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://hl7.org/fhir}DomainResource', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://hl7.org/fhir}Resource', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{urn:hl7-org:elm-types:r1}Any', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://some.other.model.org}Condition', type: 'NamedTypeSpecifier'})).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Observation', type: 'NamedTypeSpecifier'})).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Condition', type: 'IntervalTypeSpecifier'})).to.be.false;
   });
 });
 

--- a/test/stu3_test.js
+++ b/test/stu3_test.js
@@ -316,26 +316,27 @@ describe('#STU3', () => {
     ]);
   });
 
-  it('should support _typeHierarchy', () =>{
+  it('should support _typeHierarchy', () => {
     const pt = patientSource.currentPatient();
     const condition = pt.findRecord('Condition');
     expect(condition._typeHierarchy()).to.eql([
-      { name: 'Condition', namespace: 'http://hl7.org/fhir'},
-      { name: 'DomainResource', namespace: 'http://hl7.org/fhir'},
-      { name: 'Resource', namespace: 'http://hl7.org/fhir'},
-      { name: 'Any', namespace: 'urn:hl7-org:elm-types:r1'}
+      { name: '{http://hl7.org/fhir}Condition', type: 'NamedTypeSpecifier' },
+      { name: '{http://hl7.org/fhir}DomainResource', type: 'NamedTypeSpecifier' },
+      { name: '{http://hl7.org/fhir}Resource', type: 'NamedTypeSpecifier' },
+      { name: '{urn:hl7-org:elm-types:r1}Any', type: 'NamedTypeSpecifier' },
     ]);
   });
 
-  it('should support _is', () =>{
+  it('should support _is', () => {
     const pt = patientSource.currentPatient();
     const condition = pt.findRecord('Condition');
-    expect(condition._is('http://hl7.org/fhir', 'Condition')).to.be.true;
-    expect(condition._is('http://hl7.org/fhir', 'DomainResource')).to.be.true;
-    expect(condition._is('http://hl7.org/fhir', 'Resource')).to.be.true;
-    expect(condition._is('urn:hl7-org:elm-types:r1', 'Any')).to.be.true;
-    expect(condition._is('http://some.other.model.org', 'Condition')).to.be.false;
-    expect(condition._is('http://hl7.org/fhir', 'Observation')).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Condition', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://hl7.org/fhir}DomainResource', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://hl7.org/fhir}Resource', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{urn:hl7-org:elm-types:r1}Any', type: 'NamedTypeSpecifier'})).to.be.true;
+    expect(condition._is({name: '{http://some.other.model.org}Condition', type: 'NamedTypeSpecifier'})).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Observation', type: 'NamedTypeSpecifier'})).to.be.false;
+    expect(condition._is({name: '{http://hl7.org/fhir}Condition', type: 'IntervalTypeSpecifier'})).to.be.false;
   });
 });
 


### PR DESCRIPTION
This PR changes the `_is` function signature to take in a single JS Object with the type specifier information, so we don't have to do parsing in the `cql-execution` library. That object looks like:

```js
{
  name: '{http://hl7.org/fhir}Record',
  type: 'NamedTypeSpecifier',
  localId: '11',
  locator: '25:13-25:19',
}
```

In this library, we care about the `name` and `type` fields, which is why we're using `some` to test for the equality of those two fields.

This PR also refactors `typeHierarchy` to create objects for each level of the hierarchy that look like:

```js
{
  name: '{http://hl7.org/fhir}Record',
  type: 'NamedTypeSpecifier'
}
```