### PR TITLE
Allow optional trusting of meta.profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ If desired, the FHIR Data Source can be configured to use the `meta.profile` lis
 ```js
 const cqlfhir = require('cql-exec-fhir');
 
-// Passing 'true' to the constructor enables the trusted environment
-const patientSource = cqlfhir.PatientSource.FHIRv401(true); // or .FHIRv102() or .FHIRv300() or .FHIRv400()
+// Including "requireProfileTagging: true" in an object passed in to the constructor enables the trusted environment
+const patientSource = cqlfhir.PatientSource.FHIRv401({
+  requireProfileTagging: true,
+}); // or .FHIRv102() or .FHIRv300() or .FHIRv400()
 ```
 
 As an example, if an ELM Retrieve expression asks for a FHIR Condition Resource with profile `http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis`, the default behavior of the FHIR Data Source is to find any FHIR Condition resource.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,24 @@ const cqlfhir = require('cql-exec-fhir');
 // Code setting up the CQL library, executor, etc, and getting the patient data as a bundle
 // ...
 
-const patientSource = cqlfhir.PatientSource.FHIRv102(); // or .FHIRv300() or .FHIRv400()
+const patientSource = cqlfhir.PatientSource.FHIRv401(); // or .FHIRv102() or .FHIRv300() or .FHIRv400()
 patientSource.loadBundles([patient01, patient02]);
 const results = executor.exec(patientSource);
 ```
+
+## (Optional) Trusted Environment with meta.profile
+
+If desired, the FHIR Data Source can be configured to use the `meta.profile` list on FHIR resources as a source of truth for whether or not that resource should be included when looking through the Bundle of data.
+
+```js
+const cqlfhir = require('cql-exec-fhir');
+
+// Passing 'true' to the constructor enables the trusted environment
+const patientSource = cqlfhir.PatientSource.FHIRv401(true); // or .FHIRv102() or .FHIRv300() or .FHIRv400()
+```
+
+As an example, if an ELM Retrieve expression asks for a FHIR Resource with profile `http://hl7.org/fhir/StructureDefinition/Condition`, the default behavior of the FHIR Data Source is to find any FHIR Condition resource.
+With the trusted environment enabled however, the FHIR Data Source will _only_ find resources with the string `'http://hl7.org/fhir/StructureDefinition/Condition'` included in its `meta.profile` list.
 
 # Using the FHIRWrapper
 
@@ -39,7 +53,7 @@ Example:
 
 ```js
 const cqlfhir = require('cql-exec-fhir');
-const fhirWrapper = cqlfhir.FHIRWrapper.FHIRv102(); // or .FHIRv300() or .FHIRv400() or .FHIRv401()
+const fhirWrapper = cqlfhir.FHIRWrapper.FHIRv401(); // or .FHIRv102() or .FHIRv300() or .FHIRv400()
 
 const conditionRawResource = { "resourceType": "Condition", "id": "f201", "clinicalStatus": "active", ... }
 const conditionFhirObject = fhirWrapper.wrap(conditionResource)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ const results = executor.exec(patientSource);
 
 ## (Optional) Trusted Environment with meta.profile
 
+**NOTE**: This feature will only work with `cql-execution` version 2.4.1 or higher.
+
 If desired, the FHIR Data Source can be configured to use the `meta.profile` list on FHIR resources as a source of truth for whether or not that resource should be included when looking through the Bundle of data.
 
 ```js
@@ -41,8 +43,8 @@ const cqlfhir = require('cql-exec-fhir');
 const patientSource = cqlfhir.PatientSource.FHIRv401(true); // or .FHIRv102() or .FHIRv300() or .FHIRv400()
 ```
 
-As an example, if an ELM Retrieve expression asks for a FHIR Resource with profile `http://hl7.org/fhir/StructureDefinition/Condition`, the default behavior of the FHIR Data Source is to find any FHIR Condition resource.
-With the trusted environment enabled however, the FHIR Data Source will _only_ find resources with the string `'http://hl7.org/fhir/StructureDefinition/Condition'` included in its `meta.profile` list.
+As an example, if an ELM Retrieve expression asks for a FHIR Condition Resource with profile `http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis`, the default behavior of the FHIR Data Source is to find any FHIR Condition resource.
+With the trusted environment enabled however, the FHIR Data Source will _only_ find resources with the string `'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'` included in its `meta.profile` list.
 
 # Using the FHIRWrapper
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const patientSource = cqlfhir.PatientSource.FHIRv401(true); // or .FHIRv102() or
 ```
 
 As an example, if an ELM Retrieve expression asks for a FHIR Condition Resource with profile `http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis`, the default behavior of the FHIR Data Source is to find any FHIR Condition resource.
-With the trusted environment enabled however, the FHIR Data Source will _only_ find resources with the string `'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'` included in its `meta.profile` list.
+With the trusted environment enabled however, the FHIR Data Source will _only_ find resources with the string `'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'` included in their `meta.profile` lists.
 
 # Using the FHIRWrapper
 

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -322,7 +322,10 @@ class Patient extends FHIRObject {
     const records = this._bundle.entry
       .filter(e => {
         if (e.resource && e.resource.resourceType == resourceType) {
-          if (this._shouldCheckProfile) {
+          if (
+            this._shouldCheckProfile &&
+            profile !== `http://hl7.org/fhir/StructureDefinition/${resourceType}`
+          ) {
             return (
               e.resource.meta &&
               e.resource.meta.profile &&

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -319,7 +319,7 @@ class Patient extends FHIRObject {
     // profile checking will not work,
     if (requireProfileTagging === true && retrieveDetails == null) {
       throw new Error(
-        'meta.profile checking is only supported using cql-execution >=2.4.1. Please upgrade or set the "requireProfileTagging" option to false when constructing a PatientSource'
+        'meta.profile checking is only supported using cql-execution >=2.4.1. Please upgrade or set the "requireProfileTagging" option to false when constructing a PatientSource.'
       );
     }
 
@@ -354,6 +354,17 @@ class Patient extends FHIRObject {
       .map(e => {
         return new FHIRObject(e.resource, classInfo, this._modelInfo);
       });
+
+    // PatientSources have the assumption that bundles loaded in always have a Patient resources.
+    // When "requireProfileTagging" is true, we could encounter a case where the Patient resource is contained in the Bundle
+    // but does not have meta.profile set to match the Retrieve of the Patient.
+    // In this case, we should throw an error, as we want to ensure that the Patient can properly be retrieved before executing the rest of the ELM Retrieves
+    if (requireProfileTagging === true && resourceType === 'Patient' && records.length === 0) {
+      throw new Error(
+        `Patient record with meta.profile matching ${profile} was not found. Please ensure that meta.profile is properly set on the Patient resource, or set the "requireProfileTagging" option to false when constructing a PatientSource.`
+      );
+    }
+
     return records;
   }
 }

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -305,15 +305,28 @@ class Patient extends FHIRObject {
     Object.defineProperty(this, '_bundle', { value: bundle, enumerable: false });
   }
 
-  findRecord(profile) {
-    const records = this.findRecords(profile);
+  findRecord(profile, retrieveDetails) {
+    const records = this.findRecords(profile, retrieveDetails);
     if (records.length > 0) {
       return records[0];
     }
   }
 
-  findRecords(profile) {
-    const classInfo = this._modelInfo.findClass(profile);
+  findRecords(profile, retrieveDetails) {
+    // retrieveDetails was introduced in cql-execution v2.4.1. If it is missing from the function call
+    // profile checking will not work,
+    if (this._shouldCheckProfile && retrieveDetails == null) {
+      throw new Error(
+        'meta.profile checking is only supported using cql-execution >=2.4.1. Please upgrade or disable usage of meta.profile checking'
+      );
+    }
+
+    // Preferring the datatype on retrieveDetails allows the engine to properly identify resources where
+    // the ELM uses a profile from a specific IG (e.g. US Core)
+    const classInfo = this._modelInfo.findClass(
+      retrieveDetails ? retrieveDetails.datatype : profile
+    );
+
     if (classInfo == null) {
       console.error(`Failed to find type info for ${profile}`);
       return [];

--- a/test/dstu2_test.js
+++ b/test/dstu2_test.js
@@ -436,6 +436,15 @@ describe('#DSTU2 PatientSource meta.profile checking', () => {
       });
     }).to.throw();
   });
+
+  it('should find FHIR core resources even when they are not tagged with the core URL', () => {
+    const myron = patientSource.currentPatient();
+    const conditions = myron.findRecords('http://hl7.org/fhir/StructureDefinition/Condition', {
+      datatype: '{http://hl7.org/fhir}Condition',
+      templateId: 'http://hl7.org/fhir/StructureDefinition/Condition'
+    });
+    expect(conditions).to.have.length(9);
+  });
 });
 
 function compact(obj) {

--- a/test/dstu2_test.js
+++ b/test/dstu2_test.js
@@ -389,29 +389,30 @@ describe('#DSTU2 PatientSource meta.profile checking', () => {
 
   beforeEach(() => {
     // patientMyron has 1 Condition resource with a meta.profile set to be a Argonaut Condition
-    patientSource.loadBundles([patientMyron]);
+    // patientShawnee does not have an Argonaut profile included in meta.profile on any resources
+    patientSource.loadBundles([patientMyron, patientShawnee]);
   });
 
   afterEach(() => patientSource.reset());
 
   it('should throw error when trying to use meta.profile with no retrieveDetails', () => {
-    const pt = patientSource.currentPatient();
+    const myron = patientSource.currentPatient();
     expect(() =>
-      pt.findRecords('http://fhir.org/guides/argonaut/StructureDefinition/argo-condition')
+      myron.findRecords('http://fhir.org/guides/argonaut/StructureDefinition/argo-condition')
     ).to.throw();
   });
 
   it('should not find any resources without a matching meta.profile', () => {
-    const pt = patientSource.currentPatient();
-    const conditions = pt.findRecords('http://example.com/not-a-real-profile', {
+    const myron = patientSource.currentPatient();
+    const conditions = myron.findRecords('http://example.com/not-a-real-profile', {
       datatype: '{http://hl7.org/fhir}Condition'
     });
     expect(conditions).to.have.length(0);
   });
 
   it('should find resources with matching meta.profile', () => {
-    const pt = patientSource.currentPatient();
-    const conditions = pt.findRecords(
+    const myron = patientSource.currentPatient();
+    const conditions = myron.findRecords(
       'http://fhir.org/guides/argonaut/StructureDefinition/argo-condition',
       {
         datatype: '{http://hl7.org/fhir}Condition',
@@ -424,6 +425,16 @@ describe('#DSTU2 PatientSource meta.profile checking', () => {
     expect(conditions[0].meta.profile[0].value).equal(
       'http://fhir.org/guides/argonaut/StructureDefinition/argo-condition'
     );
+  });
+
+  it('should throw error if no patient resource is found with "requireProfileTagging" enabled', () => {
+    const shawnee = patientSource.nextPatient();
+    expect(() => {
+      shawnee.findRecords('http://fhir.org/guides/argonaut/StructureDefinition/argo-patient', {
+        datatype: '{http://hl7.org/fhir}Patient',
+        templateId: 'http://fhir.org/guides/argonaut/StructureDefinition/argo-patient'
+      });
+    }).to.throw();
   });
 });
 

--- a/test/fixtures/dstu2/Myron933_Ondricka197_a901d2b4-30a8-41b9-b94a-f44561d8f809.json
+++ b/test/fixtures/dstu2/Myron933_Ondricka197_a901d2b4-30a8-41b9-b94a-f44561d8f809.json
@@ -257,6 +257,9 @@
       "resource": {
         "resourceType": "Condition",
         "id": "3c57b73b-6f28-45e7-9729-b681a1ec4156",
+        "meta": {
+          "profile": ["http://fhir.org/guides/argonaut/StructureDefinition/argo-condition"]
+        },
         "patient": {
           "reference": "urn:uuid:bb5e0a4a-bcb8-448b-ab0a-69f639b7dd88"
         },
@@ -268,7 +271,7 @@
           "coding": [
             {
               "system": "http://snomed.info/sct",
-              "code": "15777000",
+              "code": "714628002",
               "display": "Prediabetes"
             }
           ],

--- a/test/fixtures/r4/Luna60_McCullough561_6662f0ca-b617-4e02-8f55-7275e9f49aa0.json
+++ b/test/fixtures/r4/Luna60_McCullough561_6662f0ca-b617-4e02-8f55-7275e9f49aa0.json
@@ -1688,7 +1688,7 @@
         "resourceType": "Condition",
         "id": "9934bc4f-58af-4ecf-bb70-b7cc31987fc5",
         "meta": {
-          "profile": ["http://hl7.org/fhir/StructureDefinition/Condition"]
+          "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis"]
         },
         "clinicalStatus": {
           "coding": [

--- a/test/fixtures/r4/Luna60_McCullough561_6662f0ca-b617-4e02-8f55-7275e9f49aa0.json
+++ b/test/fixtures/r4/Luna60_McCullough561_6662f0ca-b617-4e02-8f55-7275e9f49aa0.json
@@ -1687,6 +1687,9 @@
       "resource": {
         "resourceType": "Condition",
         "id": "9934bc4f-58af-4ecf-bb70-b7cc31987fc5",
+        "meta": {
+          "profile": ["http://hl7.org/fhir/StructureDefinition/Condition"]
+        },
         "clinicalStatus": {
           "coding": [
             {

--- a/test/fixtures/r4/Luna60_McCullough561_6662f0ca-b617-4e02-8f55-7275e9f49aa0.json
+++ b/test/fixtures/r4/Luna60_McCullough561_6662f0ca-b617-4e02-8f55-7275e9f49aa0.json
@@ -1690,6 +1690,15 @@
         "meta": {
           "profile": ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis"]
         },
+        "category": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+              "code": "encounter-diagnosis",
+              "display": "Encounter Diagnosis"
+            }
+          ]
+        },
         "clinicalStatus": {
           "coding": [
             {

--- a/test/fixtures/stu3/Myron933_Ondricka197_a901d2b4-30a8-41b9-b94a-f44561d8f809.json
+++ b/test/fixtures/stu3/Myron933_Ondricka197_a901d2b4-30a8-41b9-b94a-f44561d8f809.json
@@ -324,7 +324,8 @@
         "id": "6bf97e86-a3da-4b4b-a4e5-a290c1099719",
         "meta": {
           "profile": [
-            "http://standardhealthrecord.org/fhir/StructureDefinition/shr-encounter-EncounterPerformed"
+            "http://standardhealthrecord.org/fhir/StructureDefinition/shr-encounter-EncounterPerformed",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
           ]
         },
         "extension": [

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -434,6 +434,15 @@ describe('#R4 v4.0.1 PatientSource meta.profile checking', () => {
       });
     }).to.throw();
   });
+
+  it('should find FHIR core resources even when they are not tagged with the core URL', () => {
+    const luna = patientSource.currentPatient();
+    const conditions = luna.findRecords('http://hl7.org/fhir/StructureDefinition/Condition', {
+      datatype: '{http://hl7.org/fhir}Condition',
+      templateId: 'http://hl7.org/fhir/StructureDefinition/Condition'
+    });
+    expect(conditions).to.have.length(8);
+  });
 });
 
 function compact(obj) {

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -375,7 +375,7 @@ describe('#R4 v4.0.1', () => {
   });
 });
 
-describe('PatientSource meta.profile checking', () => {
+describe('#R4 v4.0.1 PatientSource meta.profile checking', () => {
   let patientSource;
   before(() => {
     patientSource = cqlfhir.PatientSource.FHIRv401({

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -396,7 +396,9 @@ describe('PatientSource meta.profile checking', () => {
 
   it('should find records with matching meta.profile', () => {
     const pt = patientSource.currentPatient();
-    const conditions = pt.findRecords('http://hl7.org/fhir/StructureDefinition/Condition');
+    const conditions = pt.findRecords(
+      'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
+    );
     expect(conditions).to.have.length(1);
     expect(conditions.every(c => c.getTypeInfo().name === 'Condition')).to.be.true;
     expect(conditions[0].meta.profile[0].value).equal(

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -385,31 +385,32 @@ describe('#R4 v4.0.1 PatientSource meta.profile checking', () => {
 
   beforeEach(() => {
     // patientLuna has 1 Condition resource with a meta.profile set to be a US Core Condition
-    patientSource.loadBundles([patientLuna]);
+    // patientJohnnie does not have meta.profile set on any resources
+    patientSource.loadBundles([patientLuna, patientJohnnie]);
   });
 
   afterEach(() => patientSource.reset());
 
   it('should throw error when trying to use meta.profile with no retrieveDetails', () => {
-    const pt = patientSource.currentPatient();
+    const luna = patientSource.currentPatient();
     expect(() =>
-      pt.findRecords(
+      luna.findRecords(
         'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
       )
     ).to.throw();
   });
 
   it('should not find any resources without a matching meta.profile', () => {
-    const pt = patientSource.currentPatient();
-    const conditions = pt.findRecords('http://example.com/not-a-real-profile', {
+    const luna = patientSource.currentPatient();
+    const conditions = luna.findRecords('http://example.com/not-a-real-profile', {
       datatype: '{http://hl7.org/fhir}Condition'
     });
     expect(conditions).to.have.length(0);
   });
 
   it('should find resources with matching meta.profile', () => {
-    const pt = patientSource.currentPatient();
-    const conditions = pt.findRecords(
+    const luna = patientSource.currentPatient();
+    const conditions = luna.findRecords(
       'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis',
       {
         datatype: '{http://hl7.org/fhir}Condition',
@@ -422,6 +423,16 @@ describe('#R4 v4.0.1 PatientSource meta.profile checking', () => {
     expect(conditions[0].meta.profile[0].value).equal(
       'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
     );
+  });
+
+  it('should throw error if no patient resource is found with "requireProfileTagging" enabled', () => {
+    const johnnie = patientSource.nextPatient();
+    expect(() => {
+      johnnie.findRecords('http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient', {
+        datatype: '{http://hl7.org/fhir}Patient',
+        templateId: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+      });
+    }).to.throw();
   });
 });
 

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -378,7 +378,9 @@ describe('#R4 v4.0.1', () => {
 describe('PatientSource meta.profile checking', () => {
   let patientSource;
   before(() => {
-    patientSource = cqlfhir.PatientSource.FHIRv401(true);
+    patientSource = cqlfhir.PatientSource.FHIRv401({
+      requireProfileTagging: true
+    });
   });
 
   beforeEach(() => {

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -382,27 +382,43 @@ describe('PatientSource meta.profile checking', () => {
   });
 
   beforeEach(() => {
-    // patientLuna has 1 Condition resource with a meta.profile set
+    // patientLuna has 1 Condition resource with a meta.profile set to be a US Core Condition
     patientSource.loadBundles([patientLuna]);
   });
 
   afterEach(() => patientSource.reset());
 
-  it('should not find any resources without a matching meta.profile', () => {
+  it('should throw error when trying to use meta.profile with no retrieveDetails', () => {
     const pt = patientSource.currentPatient();
-    const records = pt.findRecords('http://example.com/not-a-real-profile');
-    expect(records).to.have.length(0);
+    expect(() =>
+      pt.findRecords(
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
+      )
+    ).to.throw();
   });
 
-  it('should find records with matching meta.profile', () => {
+  it('should not find any resources without a matching meta.profile', () => {
+    const pt = patientSource.currentPatient();
+    const conditions = pt.findRecords('http://example.com/not-a-real-profile', {
+      datatype: '{http://hl7.org/fhir}Condition'
+    });
+    expect(conditions).to.have.length(0);
+  });
+
+  it('should find resources with matching meta.profile', () => {
     const pt = patientSource.currentPatient();
     const conditions = pt.findRecords(
-      'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
+      'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis',
+      {
+        datatype: '{http://hl7.org/fhir}Condition',
+        templateId:
+          'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
+      }
     );
     expect(conditions).to.have.length(1);
     expect(conditions.every(c => c.getTypeInfo().name === 'Condition')).to.be.true;
     expect(conditions[0].meta.profile[0].value).equal(
-      'http://hl7.org/fhir/StructureDefinition/Condition'
+      'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
     );
   });
 });

--- a/test/r401_test.js
+++ b/test/r401_test.js
@@ -375,6 +375,36 @@ describe('#R4 v4.0.1', () => {
   });
 });
 
+describe('PatientSource meta.profile checking', () => {
+  let patientSource;
+  before(() => {
+    patientSource = cqlfhir.PatientSource.FHIRv401(true);
+  });
+
+  beforeEach(() => {
+    // patientLuna has 1 Condition resource with a meta.profile set
+    patientSource.loadBundles([patientLuna]);
+  });
+
+  afterEach(() => patientSource.reset());
+
+  it('should not find any resources without a matching meta.profile', () => {
+    const pt = patientSource.currentPatient();
+    const records = pt.findRecords('http://example.com/not-a-real-profile');
+    expect(records).to.have.length(0);
+  });
+
+  it('should find records with matching meta.profile', () => {
+    const pt = patientSource.currentPatient();
+    const conditions = pt.findRecords('http://hl7.org/fhir/StructureDefinition/Condition');
+    expect(conditions).to.have.length(1);
+    expect(conditions.every(c => c.getTypeInfo().name === 'Condition')).to.be.true;
+    expect(conditions[0].meta.profile[0].value).equal(
+      'http://hl7.org/fhir/StructureDefinition/Condition'
+    );
+  });
+});
+
 function compact(obj) {
   if (Array.isArray(obj)) {
     return obj.map(o => compact(o));

--- a/test/r4_test.js
+++ b/test/r4_test.js
@@ -413,6 +413,56 @@ describe('#R4 v4.0.0', () => {
   });
 });
 
+describe('#R4 PatientSource meta.profile checking', () => {
+  let patientSource;
+  before(() => {
+    patientSource = cqlfhir.PatientSource.FHIRv400({
+      requireProfileTagging: true
+    });
+  });
+
+  beforeEach(() => {
+    // patientLuna has 1 Condition resource with a meta.profile set to be a US Core Condition
+    patientSource.loadBundles([patientLuna]);
+  });
+
+  afterEach(() => patientSource.reset());
+
+  it('should throw error when trying to use meta.profile with no retrieveDetails', () => {
+    const pt = patientSource.currentPatient();
+    expect(() =>
+      pt.findRecords(
+        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
+      )
+    ).to.throw();
+  });
+
+  it('should not find any resources without a matching meta.profile', () => {
+    const pt = patientSource.currentPatient();
+    const conditions = pt.findRecords('http://example.com/not-a-real-profile', {
+      datatype: '{http://hl7.org/fhir}Condition'
+    });
+    expect(conditions).to.have.length(0);
+  });
+
+  it('should find resources with matching meta.profile', () => {
+    const pt = patientSource.currentPatient();
+    const conditions = pt.findRecords(
+      'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis',
+      {
+        datatype: '{http://hl7.org/fhir}Condition',
+        templateId:
+          'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
+      }
+    );
+    expect(conditions).to.have.length(1);
+    expect(conditions.every(c => c.getTypeInfo().name === 'Condition')).to.be.true;
+    expect(conditions[0].meta.profile[0].value).equal(
+      'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition-encounter-diagnosis'
+    );
+  });
+});
+
 function compact(obj) {
   if (Array.isArray(obj)) {
     return obj.map(o => compact(o));

--- a/test/stu3_test.js
+++ b/test/stu3_test.js
@@ -454,6 +454,15 @@ describe('#STU3 PatientSource meta.profile checking', () => {
       });
     }).to.throw();
   });
+
+  it('should find FHIR core resources even when they are not tagged with the core URL', () => {
+    const myron = patientSource.currentPatient();
+    const conditions = myron.findRecords('http://hl7.org/fhir/StructureDefinition/Condition', {
+      datatype: '{http://hl7.org/fhir}Condition',
+      templateId: 'http://hl7.org/fhir/StructureDefinition/Condition'
+    });
+    expect(conditions).to.have.length(9);
+  });
 });
 
 function compact(obj) {

--- a/test/stu3_test.js
+++ b/test/stu3_test.js
@@ -407,29 +407,30 @@ describe('#STU3 PatientSource meta.profile checking', () => {
 
   beforeEach(() => {
     // patientMyron has 1 Encounter resource with a meta.profile set to be a US Core Encounter
-    patientSource.loadBundles([patientMyron]);
+    // patientShawnee does not have a US Core profile included in meta.profile on any resources
+    patientSource.loadBundles([patientMyron, patientShawnee]);
   });
 
   afterEach(() => patientSource.reset());
 
   it('should throw error when trying to use meta.profile with no retrieveDetails', () => {
-    const pt = patientSource.currentPatient();
+    const myron = patientSource.currentPatient();
     expect(() =>
-      pt.findRecords('http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter')
+      myron.findRecords('http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter')
     ).to.throw();
   });
 
   it('should not find any resources without a matching meta.profile', () => {
-    const pt = patientSource.currentPatient();
-    const encounters = pt.findRecords('http://example.com/not-a-real-profile', {
+    const myron = patientSource.currentPatient();
+    const encounters = myron.findRecords('http://example.com/not-a-real-profile', {
       datatype: '{http://hl7.org/fhir}Encounter'
     });
     expect(encounters).to.have.length(0);
   });
 
   it('should find resources with matching meta.profile', () => {
-    const pt = patientSource.currentPatient();
-    const encounters = pt.findRecords(
+    const myron = patientSource.currentPatient();
+    const encounters = myron.findRecords(
       'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter',
       {
         datatype: '{http://hl7.org/fhir}Encounter',
@@ -442,6 +443,16 @@ describe('#STU3 PatientSource meta.profile checking', () => {
     expect(encounters[0].meta.profile[1].value).equal(
       'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'
     );
+  });
+
+  it('should throw error if no patient resource is found with "requireProfileTagging" enabled', () => {
+    const shawnee = patientSource.nextPatient();
+    expect(() => {
+      shawnee.findRecords('http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient', {
+        datatype: '{http://hl7.org/fhir}Patient',
+        templateId: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+      });
+    }).to.throw();
   });
 });
 


### PR DESCRIPTION
NOTE: The logic for this was very nicely authored by @natjoe4, I have just cleaned up the git history and de-conflicted some now-irrelevant changes that were hanging around on our fork.

I also went ahead and updated the docs to use `FHIRv401` as the de-facto example, and included a section about the meta.profile trusted environment.

The following is a (modified) description from https://github.com/projecttacoma/cql-exec-fhir/pull/4, which includes more changes than is present here due to changes to code that is not relevant for this contribution:

---

## Summary
Added a flag and functionality that allows  patient sources to validate the profile passed into a findRecords call against the `meta.profile` of the found resources

### New Behavior
Patient and PatientSource now have an additional argument, `shouldCheckProfile` in their constructor as well as in the functions that call their constructor. This flag, when true, unlocks a conditional in the findRecords functions of Patient class that will filter out records found that do not have the passed in `profile` listed in their `meta.profile` array.

### Code Changes
- Added `shouldCheckProfile` flag to `PatientSource` and `Patient`
- Added functionality inside the `findRecords` function of `Patient` to filter out any found resources that do not have the passed in profile in their `meta.profile` array
- Added unit testing for new functionality, including modifying a Condition resource to actually have a `meta.profile` list