### PR TITLE
Fix "or" syntax in cql-execution peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "prettier": "^2.7.1"
   },
   "peerDependencies": {
-    "cql-execution": ">=1.3.0 | ^3.0.0-beta"
+    "cql-execution": ">=1.3.0 || ^3.0.0-beta"
   }
 }


### PR DESCRIPTION
If you use Node 16 and NPM 8 to install `cql-exec-fhir@^2.1.1` into a project using `cql-execution@2.4.3`, you'll get the following error:
> npm ERR! Could not resolve dependency:
> npm ERR! peer cql-execution@">=1.3.0 | ^3.0.0-beta" from cql-exec-fhir@2.1.1

This is because the syntax of the declared peer dependency is incorrect.  Or should be represented as `||` rather than `|`.  That has been fixed in this PR.

To test, build this branch and `pack` it into a tgz.  Then install it in the same project as before. This time it will install w/ no problems.  You can also upgrade the project to use `cql-execution@3.0.0-beta.2` and confirm it still works.