### PR TITLE
Add basic type declarations for TS users

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,35 +1,33 @@
+type RecordObject = import('cql-execution').RecordObject;
+type PatientObject = import('cql-execution').PatientObject;
+type DataProvider = import('cql-execution').DataProvider;
+type RetrieveDetails = import('cql-execution').RetrieveDetails;
+type Code = import('cql-execution').Code;
+type Date = import('cql-execution').Date;
+type Interval = import('cql-execution').Interval;
+
+class FHIRObject implements RecordObject {
+  constructor(json: any, typeInfo: any, modelInfo: any);
+  get(field: string): any;
+  getId(): string;
+  getCode(field: string): Code;
+  getDate(field: string): Date;
+  getInterval(field: string): Interval;
+  getDateOrInterval(field: string): Date | Interval;
+  _is(typeSpecifier: any): boolean;
+  _typeHierarchy(): any;
+  getTypeInfo(): any;
+}
+
+class Patient extends FHIRObject implements PatientObject {
+  constructor(bundle: any, modelInfo: any, patientSourceOptions: PatientSourceOptions);
+  findRecords(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject;
+  findRecord(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject;
+}
+
 declare module 'cql-exec-fhir' {
-  import {
-    RecordObject,
-    PatientObject,
-    DataProvider,
-    RetrieveDetails,
-    Code,
-    Date,
-    Interval
-  } from 'cql-execution';
-
-  interface PatientSourceOptions {
-    requireProfileTagging: boolean;
-  }
-
-  class FHIRObject implements RecordObject {
-    constructor(json: any, typeInfo: any, modelInfo: any);
-    get(field: string): any;
-    getId(): string;
-    getCode(field: string): Code;
-    getDate(field: string): Date;
-    getInterval(field: string): Interval;
-    getDateOrInterval(field: string): Date | Interval;
-    _is(typeSpecifier: any): boolean;
-    _typeHierarchy(): any;
-    getTypeInfo(): any;
-  }
-
-  class Patient extends FHIRObject implements PatientObject {
-    constructor(bundle: any, modelInfo: any, patientSourceOptions: PatientSourceOptions);
-    findRecords(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject;
-    findRecord(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject;
+  export interface PatientSourceOptions {
+    requireProfileTagging?: boolean;
   }
 
   export class PatientSource implements DataProvider {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ type PatientObject = import('cql-execution').PatientObject;
 type DataProvider = import('cql-execution').DataProvider;
 type RetrieveDetails = import('cql-execution').RetrieveDetails;
 type Code = import('cql-execution').Code;
-type Date = import('cql-execution').Date;
+type DateTime = import('cql-execution').DateTime;
 type Interval = import('cql-execution').Interval;
 
 class FHIRObject implements RecordObject {
@@ -11,17 +11,17 @@ class FHIRObject implements RecordObject {
   get(field: string): any;
   getId(): string;
   getCode(field: string): Code;
-  getDate(field: string): Date;
+  getDate(field: string): DateTime;
   getInterval(field: string): Interval;
-  getDateOrInterval(field: string): Date | Interval;
+  getDateOrInterval(field: string): DateTime | Interval;
   _is(typeSpecifier: any): boolean;
-  _typeHierarchy(): any;
+  _typeHierarchy(): any[];
   getTypeInfo(): any;
 }
 
 class Patient extends FHIRObject implements PatientObject {
   constructor(bundle: any, modelInfo: any, patientSourceOptions: PatientSourceOptions);
-  findRecords(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject;
+  findRecords(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject[];
   findRecord(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject;
 }
 
@@ -33,7 +33,7 @@ declare module 'cql-exec-fhir' {
   export class PatientSource implements DataProvider {
     constructor(filePathOrXML: string, patientSourceOptions?: PatientSourceOptions);
     static FHIRv102(patientSourceOptions?: PatientSourceOptions): PatientSource;
-    static FHIRv401(patientSourceOptions?: PatientSourceOptions): PatientSource;
+    static FHIRv300(patientSourceOptions?: PatientSourceOptions): PatientSource;
     static FHIRv400(patientSourceOptions?: PatientSourceOptions): PatientSource;
     static FHIRv401(patientSourceOptions?: PatientSourceOptions): PatientSource;
     get version(): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,57 @@
+declare module 'cql-exec-fhir' {
+  import {
+    RecordObject,
+    PatientObject,
+    DataProvider,
+    RetrieveDetails,
+    Code,
+    Date,
+    Interval
+  } from 'cql-execution';
+
+  interface PatientSourceOptions {
+    requireProfileTagging: boolean;
+  }
+
+  class FHIRObject implements RecordObject {
+    constructor(json: any, typeInfo: any, modelInfo: any);
+    get(field: string): any;
+    getId(): string;
+    getCode(field: string): Code;
+    getDate(field: string): Date;
+    getInterval(field: string): Interval;
+    getDateOrInterval(field: string): Date | Interval;
+    _is(typeSpecifier: any): boolean;
+    _typeHierarchy(): any;
+    getTypeInfo(): any;
+  }
+
+  class Patient extends FHIRObject implements PatientObject {
+    constructor(bundle: any, modelInfo: any, patientSourceOptions: PatientSourceOptions);
+    findRecords(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject;
+    findRecord(profile: string, retrieveDetails?: RetrieveDetails): FHIRObject;
+  }
+
+  export class PatientSource implements DataProvider {
+    constructor(filePathOrXML: string, patientSourceOptions?: PatientSourceOptions);
+    static FHIRv102(patientSourceOptions?: PatientSourceOptions): PatientSource;
+    static FHIRv401(patientSourceOptions?: PatientSourceOptions): PatientSource;
+    static FHIRv400(patientSourceOptions?: PatientSourceOptions): PatientSource;
+    static FHIRv401(patientSourceOptions?: PatientSourceOptions): PatientSource;
+    get version(): string;
+    loadBundles(bundles: any[]): void;
+    currentPatient(): Patient | undefined;
+    nextPatient(): Patient | undefined;
+    reset(): void;
+  }
+
+  export class FHIRWrapper {
+    constructor(filePathOrXML: string);
+    static FHIRv102(): FHIRWrapper;
+    static FHIRv300(): FHIRWrapper;
+    static FHIRv400(): FHIRWrapper;
+    static FHIRv401(): FHIRWrapper;
+    wrap(fhirJson: any, fhirResourceType?: string): FHIRObject;
+    _typeCastIsAllowed(currentClass: any, targetClass: any): boolean;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "url": "git@github.com:cqframework/cql-exec-fhir.git"
   },
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "scripts": {
-    "build": "babel src -d lib --copy-files",
+    "build": "babel src index.d.ts -d lib --copy-files",
     "prepublish": "npm run build",
     "test": "./node_modules/.bin/mocha --reporter spec --recursive",
     "test:watch": "npm test -- --watch",


### PR DESCRIPTION
This PR adds an `index.d.ts` file to the root of the project, which allows the TypeScript compiler in any other projects to properly pick up the module declaration. This avoids the need for TS users of cql-exec-fhir to write their own `d.ts` file for the library.

The types themselves are a mix of specific strict types and `any`s based on the information we currently have in strong type defs in `cql-execution`

**To Test**:
[minimal-ts-example.zip](https://github.com/cqframework/cql-exec-fhir/files/10070261/minimal-ts-example.zip)

The above .zip contains a minimal typescript project. The `cql-exec-fhir` dependency points to this branch.

* Unzip the file, cd into it, and run `npm install`
* In `index.ts`, you'll see that we can properly use `import` of `cql-exec-fhir` in a typescript project
* You'll get a few compiler issues, indicating the strength of the types
* Test out things like auto completion, go to definition, etc. They should be supported now with the index.d.ts file of `cql-exec-fhir`

To compare to the previous behavior,

* run `npm install cql-exec-fhir@2.1.2`
* open `index.ts`
* should get the following error in your editor instead:

![image](https://user-images.githubusercontent.com/16297930/203399672-32ee9bdf-234c-4857-8f3a-9cdd8819576a.png)


