### PR TITLE
Memoize three args

### DIFF
--- a/src/fhir.js
+++ b/src/fhir.js
@@ -8,7 +8,7 @@ const FHIRv401XML = require('./modelInfos/fhir-modelinfo-4.0.1.xml.js');
 const memoize = (fn) => {
     let cache = new Map();
     return (...args) => {
-       let cacheKey = JSON.stringify([args[0],args[3]]);
+       let cacheKey = JSON.stringify([...args]);
        if (cache.has(cacheKey)) {
          return cache.get(cacheKey);
        } else {

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -8,7 +8,7 @@ const FHIRv401XML = require('./modelInfos/fhir-modelinfo-4.0.1.xml.js');
 const memoize = (fn) => {
     let cache = new Map();
     return (...args) => {
-       let cacheKey = JSON.stringify([...args]);
+       let cacheKey = JSON.stringify([args[0],args[1],args[3]]);
        if (cache.has(cacheKey)) {
          return cache.get(cacheKey);
        } else {

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -8,7 +8,7 @@ const FHIRv401XML = require('./modelInfos/fhir-modelinfo-4.0.1.xml.js');
 const memoize = (fn) => {
     let cache = new Map();
     return (...args) => {
-       let cacheKey = JSON.stringify([...args]);
+       let cacheKey = JSON.stringify([args[0],args[3]]);
        if (cache.has(cacheKey)) {
          return cache.get(cacheKey);
        } else {

--- a/src/fhir.js
+++ b/src/fhir.js
@@ -5,6 +5,20 @@ const FHIRv300XML = require('./modelInfos/fhir-modelinfo-3.0.0.xml.js');
 const FHIRv400XML = require('./modelInfos/fhir-modelinfo-4.0.0.xml.js');
 const FHIRv401XML = require('./modelInfos/fhir-modelinfo-4.0.1.xml.js');
 
+const memoize = (fn) => {
+    let cache = new Map();
+    return (...args) => {
+       let cacheKey = JSON.stringify([...args]);
+       if (cache.has(cacheKey)) {
+         return cache.get(cacheKey);
+       } else {
+            let result = fn(...args);
+            cache.set(cacheKey, result);
+            return result;
+        }
+    }
+}
+
 class FHIRWrapper {
   constructor(filePathOrXML) {
     this._modelInfo = load(filePathOrXML);
@@ -488,6 +502,9 @@ function toSystemObject(data, name) {
   }
 }
 
+
+
+const toFHIRObject = memoize(_toFHIRObject) 
 /**
  * Converts data to a FHIRObject class instance
  * @param {Object} data - the JSON data to populate the FHIR object with
@@ -496,7 +513,7 @@ function toSystemObject(data, name) {
  * @param {string} suffix - the trailing part of the path to get (e.g., x.y.z)
  * @returns {FHIRObject}
  */
-function toFHIRObject(data, typeSpecifier, modelInfo, suffix) {
+function _toFHIRObject(data, typeSpecifier, modelInfo, suffix) {
   if (data == null) {
     // preserve distinction between null or undefined
     return data;


### PR DESCRIPTION
Another performance optimization for ccsm-cds
The 3rd argument to the `toFHIRObject` function is the same in every call when used in ccsm-cds. 
It is a lengthy argument, so removing it from the JSON.stringify yields about 10% faster results. 
